### PR TITLE
Fixes sizing of images 

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -91,7 +91,7 @@ body .ScreenshotCarousel-navitem {border:0px !important;background-color:#24292e
 body .ScreenshotCarousel-navitem.selected {border:0px !important;background-color:#1c1f21 !important;}
 body .border-gray-light {border:0px !important;background:transparent !important;}
 body .position-relative > .position-absolute {background:transparent !important;}
-body .position-relative {background:transparent}
+body .position-relative {background-color:transparent}
 body .Story, .topic-box {background-color:#24292e !important;border-radius:5px !important;margin-right:10px;}
 body .pagination span, .pagination a {background-color:#24292e !important;border:0px !important;}
 body .pagination .current {background-color:#272c32 !important;border:0px !important;}


### PR DESCRIPTION
The previous background CSS property was overriding background-size,  causing this:

![Screenshot from 2020-03-25 19-28-16](https://user-images.githubusercontent.com/1587455/77578060-c922ad00-6ecf-11ea-8d4c-5a6f546a4d8e.png)

It is fixed in this PR

I don't think the `.position-relative` class should really have color information in the first place, but as the git logs aren't clear about why it was added, I've left it in