### PR TITLE
Adds dark version of signup box on repo pages

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -285,4 +285,4 @@ body .RecentBranches a.btn {color: rgb(250, 250, 250) !important;}
 body .RecentBranches a.btn .octicon > path {fill: rgb(250, 250, 250) !important;}
 body .Box-row--gray {background-color: rgb(45, 51, 58); border-top: none;}
 body .related-issue-item.navigation-focus, body .similar-issue-item.navigation-focus {background-color:rgb(29, 33, 37);}
-
+body .signup-prompt-bg {background-image:linear-gradient(180deg,hsla(0,0%,100%,0) 50%,#272c32),linear-gradient(70deg,#24292e 32%,#272c32)}


### PR DESCRIPTION
Signup box now looks like:

![Screenshot from 2020-03-25 19-45-26](https://user-images.githubusercontent.com/1587455/77578936-531f4580-6ed1-11ea-8aec-ca5f691c8db5.png)
