### PR TITLE
Adds dark background/border to copyable-terminal areas

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -285,4 +285,4 @@ body .RecentBranches a.btn {color: rgb(250, 250, 250) !important;}
 body .RecentBranches a.btn .octicon > path {fill: rgb(250, 250, 250) !important;}
 body .Box-row--gray {background-color: rgb(45, 51, 58); border-top: none;}
 body .related-issue-item.navigation-focus, body .similar-issue-item.navigation-focus {background-color:rgb(29, 33, 37);}
-
+body .copyable-terminal {background: rgb(39, 44, 50) !important;border: 1px solid rgb(29, 33, 37) !important;}


### PR DESCRIPTION
Fixes the copyable terminal (the multi-line copy/paste field) to have a dark background/border

You can see these fields on the empty repository page for a repository you own.